### PR TITLE
Clarified combing certs for auto registration

### DIFF
--- a/developerguide/device-certs-your-own.md
+++ b/developerguide/device-certs-your-own.md
@@ -133,7 +133,7 @@ You can use a CA certificate registered with AWS IoT to create a device certific
 1. (Required for [auto-registration](#auto-register-device-cert)) Create a certificate file that contains the device certificate and your CA certificate. Here is the Linux command:
 
    ```
-   cat deviceCert.crt sampleCACertificate.pem > deviceCertAndCACert.crt
+   cat deviceCert.pem rootCA.pem > deviceCertAndCACert.crt
    ```
    
    Use ```deviceCertAndCACert.crt``` as the device certificate when connecting to AWS IoT. It is important to note that to connect to AWS IoT you will need to use the AWS IoT root certificate to verify the servers identity. You can find that certificate [here](https://www.amazontrust.com/repository/AmazonRootCA1.pem). By combining your own CA certificate and the newly generate certificate in the device certificate AWS IoT will be able to identify your own CA and autoregister the newly generated certificate.

--- a/developerguide/device-certs-your-own.md
+++ b/developerguide/device-certs-your-own.md
@@ -130,6 +130,14 @@ You can use a CA certificate registered with AWS IoT to create a device certific
    ```
    openssl x509 -req -in deviceCert.csr -CA rootCA.pem -CAkey rootCA.key -CAcreateserial -out deviceCert.pem -days 500 -sha256
    ```
+1. (Required for [auto-registration](#auto-register-device-cert)) Create a certificate file that contains the device certificate and your CA certificate. Here is the Linux command:
+
+   ```
+   cat deviceCert.crt sampleCACertificate.pem > deviceCertAndCACert.crt
+   ```
+   
+   Use ```deviceCertAndCACert.crt``` as the device certificate when connecting to AWS IoT. It is important to note that to connect to AWS IoT you will need to use the AWS IoT root certificate to verify the servers identity. You can find that certificate [here](https://www.amazontrust.com/repository/AmazonRootCA1.pem). By combining your own CA certificate and the newly generate certificate in the device certificate AWS IoT will be able to identify your own CA and autoregister the newly generated certificate.
+   
 **Note**  
 You must use the CA certificate registered with AWS IoT to create device certificates\. If you have more than one CA certificate \(with the same subject field and public key\) registered in your AWS account, you must specify the CA certificate used to create the device certificate when you register your device certificate\.
 


### PR DESCRIPTION
Added clarification about how to combine certificates needed for auto registration.

*Issue #, if available:*
NA
*Description of changes:*
I added  bullet point on how to combine the CA cert and device cert and explained how it is different from the AWS IoT root cert. This was missing from this guide in my opinion. I found the solution in this [blog post](https://aws.amazon.com/blogs/iot/just-in-time-registration-of-device-certificates-on-aws-iot/), but feel it belongs here. I'm not quite sure if it should be in the section where I put it. Maybe it should go in the JITR section.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
