### PR TITLE
Change SNS message format from JSON to RAW.

### DIFF
--- a/developerguide/iot-sns-rule.md
+++ b/developerguide/iot-sns-rule.md
@@ -37,7 +37,7 @@ In this tutorial, you create a rule that sends the name of the AWS IoT thing tha
 1. A new tab opens in your browser\. Enter a topic name, and then choose **Create**\.  
 ![\[Image NOT FOUND\]](http://alpha-docs-aws.amazon.com/iot/latest/developerguide/images/sns-name-topic.png)
 
-1. On the **Configure action** page, for **SNS target**, choose the SNS topic you just created\. For **Message format**, choose **JSON**\. For **IAM role name**, choose **Create a new role**\.  
+1. On the **Configure action** page, for **SNS target**, choose the SNS topic you just created\. For **Message format**, choose **RAW**\. For **IAM role name**, choose **Create a new role**\.  
 ![\[Image NOT FOUND\]](http://alpha-docs-aws.amazon.com/iot/latest/developerguide/images/sns-configure-action-1.png)
 
 1. Enter a name for the role, and then choose **Create a new role**\.  


### PR DESCRIPTION
JSON is an SNS-specific message type, which requires the source IoT message to be formatted in a specific way. 

This will cause IoT rules to fail to pass the message to an SNS topic.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
