### PR TITLE
Update developerguide/server-authentication.md

### DIFF
--- a/developerguide/server-authentication.md
+++ b/developerguide/server-authentication.md
@@ -40,7 +40,7 @@ Depending on which type of data endpoint you are using and which cipher suite yo
 + ECC 256 bit key: [Amazon Root CA 3](https://www.amazontrust.com/repository/AmazonRootCA3.pem)\.
 + ECC 384 bit key: Amazon Root CA 4\. Reserved for future use\.
 
-These certificates are all cross\-signed by the [ Starfield Root CA Certificate](https://www.amazontrust.com/repository/SFSRootCAG2.pem)\. All new AWS IoT Core regions, beginning with the May 9, 2018 launch of AWS IoT Core in the Asia Pacific \(Mumbai\) Region, serve only ATS certificates\.
+These certificates are all cross\-signed by the [ Starfield Root CA Certificate](https://ssl-ccp.godaddy.com/repository/sf-class2-root.crt)\. All new AWS IoT Core regions, beginning with the May 9, 2018 launch of AWS IoT Core in the Asia Pacific \(Mumbai\) Region, serve only ATS certificates\.
 
 ## Server Authentication Guidelines<a name="server-authentication-guidelines"></a>
 
@@ -52,7 +52,7 @@ There are many variables that can affect a device's ability to validate the AWS 
   + [Cross\-signed Amazon Root CA 2](https://www.amazontrust.com/repository/G2-RootCA2.pem) \- Reserved for future use\.
   + [Cross\-signed Amazon Root CA 3](https://www.amazontrust.com/repository/G2-RootCA3.pem)
   + [Cross\-signed Amazon Root CA 4 \- Reserved for future use\.](https://www.amazontrust.com/repository/G2-RootCA4.pem)
-+ If you are experiencing server certificate validation issues, your device may need to explicitly trust the root CA\. Try adding the [Starfield Root CA Certificate](https://www.amazontrust.com/repository/SFSRootCAG2.pem) to your trust store\.
++ If you are experiencing server certificate validation issues, your device may need to explicitly trust the root CA\. Try adding the [Starfield Root CA Certificate](https://ssl-ccp.godaddy.com/repository/sf-class2-root.crt) to your trust store\.
 + If you still experience issues after executing the steps above, please contact [AWS Developer Support](https://aws.amazon.com/premiumsupport/plans/developers/)\. 
 
 **Note**  


### PR DESCRIPTION
*Issue #, if available:* Starfield Services Root Certificate Authority - G2 shouldn't be the Root CA used to sign Server Certificate(Amazon Root CA 1), it is just an intermittent CA. 

*Description of changes:*

openssl s_client -showcerts -cert "device.crt" -key "device-private.key" -connect "xxxx-ats.iot.ap-southeast-2.amazonaws.com:8883"
Below is the Certificate chain

 0 s:/CN=*.iot.ap-southeast-2.amazonaws.com
   i:/C=US/O=Amazon/OU=Server CA 1B/CN=Amazon
 1 s:/C=US/O=Amazon/OU=Server CA 1B/CN=Amazon
   i:/C=US/O=Amazon/CN=Amazon Root CA 1
 2 s:/C=US/O=Amazon/CN=Amazon Root CA 1
   i:/C=US/ST=Arizona/L=Scottsdale/O=Starfield Technologies, Inc./CN=Starfield Services Root Certificate Authority - G2
 3 s:/C=US/ST=Arizona/L=Scottsdale/O=Starfield Technologies, Inc./CN=Starfield Services Root Certificate Authority - G2
   i:/C=US/O=Starfield Technologies, Inc./OU=Starfield Class 2 Certification Authority

The server certificate used to sign Amazon Root CA 1 should be Starfield Class 2 Certification Authority (https://ssl-ccp.godaddy.com/repository/sf-class2-root.crt). The one mentioned currently in Developer guide is  "Starfield Root CA Certificate"(https://www.amazontrust.com/repository/SFSRootCAG2.pem) is just the intermediate CA, not the Root CA to sign server certificate. If use Certificate Pining technique, or mbedTLS which requires to bind with RootCA will need to bind with the Root CA, not the intermediate CA.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
