### PR TITLE
Provide more typical iot:Subscribe policy including iot:Receive

### DIFF
--- a/developerguide/pub-sub-policy.md
+++ b/developerguide/pub-sub-policy.md
@@ -100,6 +100,15 @@ For devices registered as things in the registry, the following policy grants pe
             "Resource": [
                 "arn:aws:iot:us-east-1:123456789012:topicfilter/${iot:Connection.Thing.ThingName}/room*"
             ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "iot:Receive"
+            ],
+            "Resource": [
+                "arn:aws:iot:us-east-1:123456789012:topic/${iot:Connection.Thing.ThingName}/room*"
+            ]
         }
     ]
 }
@@ -132,6 +141,15 @@ For devices not registered as things in the registry, the following policy grant
             ],
             "Resource": [
                 "arn:aws:iot:us-east-1:123456789012:topicfilter/${iot:ClientId}/room*"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "iot:Receive"
+            ],
+            "Resource": [
+                "arn:aws:iot:us-east-1:123456789012:topic/${iot:ClientId}/room*"
             ]
         }
     ]


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Given that any `iot:Subscribe` permission has to be paired with `iot:Receive` in order for the device to actually receive the messages it subscribes to, I'm updating the first 'Subscribe' example to include this. 

I'm not sure if this is the best example to use, but the only existing one that includes it is with respect to web socket clients.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
