### PR TITLE
Missing word "to"

### DIFF
--- a/developerguide/iot-provision.md
+++ b/developerguide/iot-provision.md
@@ -5,7 +5,7 @@ When you provision a device with AWS IoT, you must create resources so your devi
 
   IoT things are entries in the AWS IoT device registry\. Each thing has a unique name and set of attributes, and is associated with a physical device\. Things can be defined using a thing type or grouped into thing groups\. For more information, see [Managing Devices with AWS IoT ](iot-thing-management.md)\.
 
-   Although not required, creating a thing makes it possible manage your device fleet more effectively by searching for devices by thing type, thing group, and thing attributes\. For more information, see [Fleet Indexing Service](iot-indexing.md)\.
+   Although not required, creating a thing makes it possible to manage your device fleet more effectively by searching for devices by thing type, thing group, and thing attributes\. For more information, see [Fleet Indexing Service](iot-indexing.md)\.
 + An X\.509 certificate\.
 
   Devices use X\.509 certificates to perform mutual authentication with AWS IoT\. You can register an existing certificate or have AWS IoT generate and register a new certificate for you\. You associate a certificate with a device by attaching it to the thing that represents the device\. You must also copy the certificate and associated private key onto the device\. Devices present the certificate when connecting to AWS IoT\. For more information, see [Authentication](authentication.md)\.


### PR DESCRIPTION
The word "to" was missing. "Although not required, creating a thing makes it possible **to** manage your device fleet more effectively by searching for devices by thing type, thing group, and thing attributes\."

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
