### PR TITLE
V1 or V2 logging not mentioned anywhere

### DIFF
--- a/developerguide/audit-chk-logging-disabled.md
+++ b/developerguide/audit-chk-logging-disabled.md
@@ -1,6 +1,6 @@
 # LOGGING\_DISABLED\_CHECK<a name="audit-chk-logging-disabled"></a>
 
-AWS IoT logs are not enabled in Amazon CloudWatch\.
+AWS IoT logs [V1](https://docs.aws.amazon.com/iot/latest/apireference/API_SetLoggingOptions.html) or [V2](https://docs.aws.amazon.com/iot/latest/apireference/API_SetV2LoggingOptions.html) are not enabled in Amazon CloudWatch\.
 
 Severity: **Low**
 


### PR DESCRIPTION
*Issue #, if available:* N/A.

*Description of changes:* Updated doc to explicitly say that it verifies both V1 and V2 logging for the LOGGING_DISABLED_CHECK audit.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.