### PR TITLE
Typo in iot:AssumeRoleWithCertificate policy

### DIFF
--- a/developerguide/authorizing-direct-aws.md
+++ b/developerguide/authorizing-direct-aws.md
@@ -84,11 +84,15 @@ Although the credential lifetime specified in the IAM role can be longer, when A
    ```
    {
        "Version": "2012-10-17",
-       "Statement": {
+       "Statement": 
+       [
+       {
+         
            "Effect": "Allow",
            "Action": "iot:AssumeRoleWithCertificate",
            "Resource": "arn:aws:iot:your region:your_aws_account_id:rolealias/your role alias"
        }
+       ]
    }
    ```
 


### PR DESCRIPTION
*Issue #, if available:*

There is a typo (missing []) in iot:AssumeRoleWithCertificate policy description resulting in an error when using console

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
