### PR TITLE
Changed thingGroupName to thingGroupNames in search-index syntax

### DIFF
--- a/developerguide/example-thinggroup-queries.md
+++ b/developerguide/example-thinggroup-queries.md
@@ -8,9 +8,9 @@ Queries are specified in a query string using a query syntax and passed to the [
 | Query string | Result | 
 | --- | --- | 
 |  abc  |  Queries for "abc" in any field\.  | 
-|  thingGroupName:myGroupThingName  |  Queries for a thing group with name "myGroupThingName"\.  | 
-|  thingGroupName:my\*  |  Queries for thing groups with names that begin with "my"\.  | 
-|  thingGroupName:ab?  |  Queries for thing groups with names that have "ab" plus one additional character \(for example: "aba", "abb", "abc", and so on\.\)  | 
+|  thingGroupNames:myGroupThingName  |  Queries for a thing group with name "myGroupThingName"\.  | 
+|  thingGroupNames:my\*  |  Queries for thing groups with names that begin with "my"\.  | 
+|  thingGroupNames:ab?  |  Queries for thing groups with names that have "ab" plus one additional character \(for example: "aba", "abb", "abc", and so on\.\)  | 
 |  attributes\.myAttribute:75  |  Queries for thing groups with an attribute named "myAttribute" that has the value 75\.  | 
 |  attributes\.myAttribute:\[75 TO 80\]  |  Queries for thing groups with an attribute named "myAttribute" whose value falls within a numeric range \(75–80, inclusive\)\.  | 
 |  attributes\.myAttribute:\[75 TO 80\]  |  Queries for thing groups with an attribute named "myAttribute" whose value falls within the numeric range \(>75 and <=80\)\.  | 

--- a/developerguide/thinggroup-index.md
+++ b/developerguide/thinggroup-index.md
@@ -59,7 +59,7 @@ aws iot describe-index --index-name "AWS_ThingGroups"
 Use the search\-index CLI command to query data in the index:
 
 ```
-aws iot search-index --index-name "AWS_ThingGroups" --query-string "thingGroupName:mythinggroup*"
+aws iot search-index --index-name "AWS_ThingGroups" --query-string "thingGroupNames:mythinggroup*"
 ```
 
 ## Authorization<a name="query-thinggroup-auth"></a>


### PR DESCRIPTION
The correct field name is thingGroupNames.

Using thingGroupName in search-index calls results in the following error:

`An error occurred (InvalidQueryException) when calling the SearchIndex operation: Unable to parse query, invalid field name, field name: thingGroupName, query string: thingGroupName:mythinggroup`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
