### PR TITLE
docs: correct metricTimestamp definition

### DIFF
--- a/developerguide/cloudwatch-metrics-rule-action.md
+++ b/developerguide/cloudwatch-metrics-rule-action.md
@@ -30,7 +30,7 @@ A string that contains the CloudWatch metric value\.
 Supports substitution templates: Yes
 
 `metricTimestamp`  
-\(Optional\) A string that contains the timestamp, expressed in milliseconds in Unix epoch time\. Defaults to the current Unix epoch time\.  
+\(Optional\) A string that contains the timestamp, expressed in seconds in Unix epoch time\. Defaults to the current Unix epoch time\.  
 Supports substitution templates: Yes
 
 `roleArn`  


### PR DESCRIPTION
`metricTimestamp` should be in seconds rather than milliseconds, this now matches the Iot Rule example below

*Issue #, if available:*

*Description of changes:*

Documentation seemed to be wrong, I've only got this to work with a string formatted epoch in seconds and not milliseconds.

If I tried specifying the timestamp in milliseconds I got the following error message:
> The parameter MetricData.member.1.Timestamp must specify a time within the past two weeks

There was also inconsistencies between the field definition and the example rule below

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
