### PR TITLE
Replace default topic with correct value

### DIFF
--- a/developerguide/iot-quick-start.md
+++ b/developerguide/iot-quick-start.md
@@ -89,7 +89,7 @@ Here are some ideas to explore AWS IoT further after you complete the quick star
 + 
 
 **[View MQTT messages in the MQTT client](https://console.aws.amazon.com/iot/home#/test)**  
-From the [AWS IoT console](https://console.aws.amazon.com/iot/home) you can open the [MQTT client](https://console.aws.amazon.com/iot/home#/test) on the **Test** page of the AWS IoT console\. In the **MQTT client**, subscribe to **topic\_1**, and then, on your device, run the program \./start\.sh as described in the previous step\. See [View MQTT messages with the AWS IoT MQTT client](view-mqtt-messages.md) for more information\.
+From the [AWS IoT console](https://console.aws.amazon.com/iot/home) you can open the [MQTT client](https://console.aws.amazon.com/iot/home#/test) on the **Test** page of the AWS IoT console\. In the **MQTT client**, subscribe to **sdk/test/Python**, and then, on your device, run the program \./start\.sh as described in the previous step\. See [View MQTT messages with the AWS IoT MQTT client](view-mqtt-messages.md) for more information\.
 + 
 
 **[Try the AWS IoT Core interactive demo](interactive-demo.md)**  


### PR DESCRIPTION
The topic "topic_1" does not seem to be the default value.
Referring to https://github.com/aws/aws-iot-device-sdk-python/blob/master/samples/basicPubSub/basicPubSub.py it seems the default topic is instead "sdk/test/Python".

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
