### PR TITLE
Specify correct console to create SNS subscription

### DIFF
--- a/developerguide/iot-moisture-create-sns-topic.md
+++ b/developerguide/iot-moisture-create-sns-topic.md
@@ -2,9 +2,7 @@
 
 Create an Amazon SNS topic and subscription\.
 
-1. From the AWS IoT console, choose **Services**, type **SNS**, and then choose **Simple Notification Service**\.
-
-1. In the navigation pane, choose **Topics**, and then choose **Create topic**\.
+1. From the [AWS SNS console](https://console.aws.amazon.com/sns/home), in the navigation pane, choose **Topics**, and then choose **Create topic**\.
 
 1. Enter a name for the topic \(for example, **MoistureSensorTopic**\)\.
 


### PR DESCRIPTION
Docs are wrong, there is no `create topic` in IOT, it only exists in SQS.