### PR TITLE
Fix an error in the combined IoT/LoRaWAN trust policy

### DIFF
--- a/developerguide/configure-logging.md
+++ b/developerguide/configure-logging.md
@@ -158,8 +158,10 @@ Trust policy to log AWS IoT Core and AWS IoT Core for LoRaWAN activity:
           "Sid": "",
           "Effect": "Allow",
           "Principal": {
-            "Service": "iot.amazonaws.com",
-            "Service": "iotwireless.amazonaws.com"
+            "Service": [
+              "iot.amazonaws.com",
+              "iotwireless.amazonaws.com"
+            ]
           },
           "Action": "sts:AssumeRole"
         }


### PR DESCRIPTION
The combined trust policy seems to have been combined in a faulty way. The services must be a list.

*Description of changes:*
Fix a faulty trust policy.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
