### PR TITLE
Remove the space after \

### DIFF
--- a/developerguide/http.md
+++ b/developerguide/http.md
@@ -92,7 +92,7 @@ You can use [curl](https://curl.haxx.se) from a client or device to send a messa
        --cacert Amazon-root-CA-1.pem \
        --cert device.pem.crt \
        --key private.pem.key \
-       --request POST \ 
+       --request POST \
        --data "{ \"message\": \"Hello, world\" }" \
        "https://IoT_data_endpoint:8443/topics/topic?qos=1"
    ```  


### PR DESCRIPTION
*Issue #, if available:*

The curl command doesn't work if there is a space after \

This is caught by: https://github.com/koalaman/shellcheck/wiki/SC1101

*Description of changes:*

Removed the space after \

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
