### PR TITLE
Tutorial: Linux/MacOS guide should not use Windows commands

### DIFF
--- a/developerguide/using-laptop-as-device.md
+++ b/developerguide/using-laptop-as-device.md
@@ -212,7 +212,7 @@ Before running the script, make sure your thing's policy provides permissions fo
 1. In your command line window, replace *your\-iot\-endpoint* as indicated and run this command\. 
 
    ```
-   python pubsub.py --endpoint your-iot-endpoint --root-ca %USERPROFILE%\certs\Amazon-root-CA-1.pem --cert %USERPROFILE%\certs\device.pem.crt --key %USERPROFILE%\certs\private.pem.key
+   python pubsub.py --endpoint your-iot-endpoint --root-ca ~/certs/Amazon-root-CA-1.pem --cert ~/certs/device.pem.crt --key ~/certs/private.pem.key
    ```
 
 ------


### PR DESCRIPTION
*Description of changes:*

The command given for Linux/MacOS was clearly a Windows command.


_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
