### PR TITLE
"bucket" property should be "bucketName"

### DIFF
--- a/developerguide/rule-error-handling.md
+++ b/developerguide/rule-error-handling.md
@@ -68,7 +68,7 @@ Here is an example of a rule with an added error action\. The following rule has
     "errorAction" : { 
         "s3" : {
             "roleArn": "arn:aws:iam::123456789012:role/aws_iot_s3",
-            "bucket" : "message-processing-errors",
+            "bucketName" : "message-processing-errors",
             "key" : "${replace(topic(), '/', '-') + '-' + timestamp() + '-' + newuuid()}"
         }
     }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
"bucket" property should be "bucketName" otherwise the CLI gives the error:
```
Missing required parameter in topicRulePayload.errorAction.s3: "bucketName"
Unknown parameter in topicRulePayload.errorAction.s3: "bucket", must be one of: roleArn, bucketName, key, cannedAcl
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
