### PR TITLE
Use hyphen-minus in curl command

### DIFF
--- a/developerguide/authorizing-direct-aws.md
+++ b/developerguide/authorizing-direct-aws.md
@@ -119,7 +119,7 @@ The *ThingName* that you provide in `x-amzn-iot-thingname` must match the name o
 
    Use the endpoint to make an HTTPS request to the credentials provider to return a security token\. The following example command uses `curl`, but you can use any HTTP client\.
 
-   curl ‐‐cert *your certificate* \-\-key *your device certificate key pair* \-H "x\-amzn\-iot\-thingname: *your thing name*" \-\-cacert AmazonRootCA1\.pem https://*your endpoint* /role\-aliases/*your role alias*/credentials
+   curl --cert *your certificate* \-\-key *your device certificate key pair* \-H "x\-amzn\-iot\-thingname: *your thing name*" \-\-cacert AmazonRootCA1\.pem https://*your endpoint* /role\-aliases/*your role alias*/credentials
 
    This command returns a security token object that contains an `accessKeyId`, a `secretAccessKey`, a `sessionToken`, and an expiration\. The following JSON object is sample output of the `curl` command\.
 

--- a/developerguide/authorizing-direct-aws.md
+++ b/developerguide/authorizing-direct-aws.md
@@ -119,7 +119,7 @@ The *ThingName* that you provide in `x-amzn-iot-thingname` must match the name o
 
    Use the endpoint to make an HTTPS request to the credentials provider to return a security token\. The following example command uses `curl`, but you can use any HTTP client\.
 
-   curl --cert *your certificate* \-\-key *your device certificate key pair* \-H "x\-amzn\-iot\-thingname: *your thing name*" \-\-cacert AmazonRootCA1\.pem https://*your endpoint* /role\-aliases/*your role alias*/credentials
+   curl \-\-cert *your certificate* \-\-key *your device certificate key pair* \-H "x\-amzn\-iot\-thingname: *your thing name*" \-\-cacert AmazonRootCA1\.pem https://*your endpoint* /role\-aliases/*your role alias*/credentials
 
    This command returns a security token object that contains an `accessKeyId`, a `secretAccessKey`, a `sessionToken`, and an expiration\. The following JSON object is sample output of the `curl` command\.
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The file `authorizing-direct-aws.md` contained the following line: `curl ‐‐cert`. This uses a hyphen, Unicode code point U+2010, instead of the hyphen-minus, Unicode code point U+002D. If anyone tried to copy and paste this into a terminal, they would encounter an error as `curl` would interpret this as a hostname instead of a command line option. This changes the hyphen to a hyphen-minus.
Before the change:
```
$ file authorizing-direct-aws.md
authorizing-direct-aws.md: UTF-8 Unicode text, with very long lines
```
After:
```
$ file authorizing-direct-aws.md
authorizing-direct-aws.md: ASCII text, with very long lines
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
