### PR TITLE
Update: VPC Destination Policy updated from oneclick policy generated by console

### DIFF
--- a/developerguide/vpc-rule-action.md
+++ b/developerguide/vpc-rule-action.md
@@ -32,22 +32,45 @@ This ARN should have a policy attached to it that looks like the following examp
 
 ```
 {
-"Version": "2012-10-17",
-"Statement": [
-{
-    "Effect": "Allow",
-    "Action": [
-        "ec2:CreateNetworkInterface",
-        "ec2:DescribeNetworkInterfaces",
-        "ec2:CreateNetworkInterfacePermission",
-        "ec2:DeleteNetworkInterface",
-        "ec2:DescribeSubnets",
-        "ec2:DescribeVpcs",
-        "ec2:DescribeVpcAttribute"
-        ],
-        "Resource": "*"
-    }
-]
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:CreateNetworkInterface",
+                "ec2:DescribeNetworkInterfaces",
+                "ec2:DescribeVpcs",
+                "ec2:DeleteNetworkInterface",
+                "ec2:DescribeSubnets",
+                "ec2:DescribeVpcAttribute",
+                "ec2:DescribeSecurityGroups"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": "ec2:CreateNetworkInterfacePermission",
+            "Resource": "*",
+            "Condition": {
+                "StringEquals": {
+                    "ec2:ResourceTag/VPCDestinationENI": "true"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:CreateTags"
+            ],
+            "Resource": "*",
+            "Condition": {
+                "StringEquals": {
+                    "ec2:CreateAction": "CreateNetworkInterface",
+                    "aws:RequestTag/VPCDestinationENI": "true"
+                }
+            }
+        }
+    ]
 }
 ```
 


### PR DESCRIPTION
*Issue #, if available:*
VPC destination role policy provided in the doc is missing ```DescribeSecurityGroups``` due to which an error is displayed on the console. The new implementation of VPC destination creation requires ```ec2:DescribeSecurityGroups``` permissions.

*Description of changes:*
Updated the VPC destination role policy with the new policy, which is taken from the one-click generate policy option in IoT Console page. 

https://console.aws.amazon.com/iot/home?region=us-east-1#/create/vpcdestination  -> CreateRole


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
