### PR TITLE
Update iot-sql-where.md

### DIFF
--- a/developerguide/iot-sql-where.md
+++ b/developerguide/iot-sql-where.md
@@ -13,3 +13,11 @@ SQL: `SELECT color AS my_color FROM 'topic/subtopic' WHERE temperature > 50 AND 
 In this case, the rule would be triggered, but the actions specified by the rule would not be performed\. There would be no outgoing payload\.
 
 You can use functions and operators in the WHERE clause\. However, you cannot reference any aliases created with the AS keyword in the SELECT\. The WHERE clause is evaluated first, to determine if SELECT is evaluated\. 
+
+Example with non-JSON payload:
+
+Incoming non-JSON payload published on `topic/subtopic`: `80`\.
+
+SQL: `SELECT decode(encode(*, 'base64'), 'base64') AS value FROM 'topic/subtopic' WHERE decode(encode(*, 'base64'), 'base64') > 50`\.
+
+In this case, the rule would be triggered, and the actions specified by the rule would be performed\. Outgoing payload would be transformed by the SELECT clause as a JSON payload `{"value":80}`\.


### PR DESCRIPTION
Even if mentions are made to functions usage in WHERE clause, it is not obvious to come up with a working solution for non JSON payloads. A simple example of WHERE clause on a raw (non-JSON) payload like integer payload>80 would have been useful to me, hence the proposal 8)

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
