### PR TITLE
Add HTTPS over 443

### DIFF
--- a/developerguide/http.md
+++ b/developerguide/http.md
@@ -27,7 +27,7 @@ https://IoT_data_endpoint/topics/url_encoded_topic_name?qos=1"
 These are some examples of how to send an HTTPS message to AWS IoT\.
 
 ------
-#### [ Python ]
+#### [ Python (port 8443) ]
 
 ```
 import requests
@@ -60,6 +60,36 @@ publish = requests.request('POST',
 print("Response status: ", str(publish.status_code))
 if publish.status_code == 200:
         print("Response body:", publish.text)
+```
+
+------
+#### [ Python (port 443) ]
+
+```
+import http.client
+import json
+import ssl
+
+ssl_context = ssl.SSLContext(protocol=ssl.PROTOCOL_TLS_CLIENT)
+ssl_context.minimum_version = ssl.TLSVersion.TLSv1_2
+
+# Note the use of ALPN
+ssl_context.set_alpn_protocols(["x-amzn-http-ca"])
+ssl_context.load_verify_locations(cafile="./<root_certificate>")
+
+## Kindly Update the Certificate and AWS endpoint on following lines
+
+ssl_context.load_cert_chain("./<certificate_in_PEM_Format>", "<private_key_in_PEM_format>")
+connection = http.client.HTTPSConnection('<the ats IoT endpoint>', 443, context=ssl_context)
+message = {'data': 'Hello using TLS Client authentication!'}
+json_data = json.dumps(message)
+connection.request('POST', '/topics/device%2Fmessage?qos=1', json_data)
+
+# make request
+response = connection.getresponse()
+
+# print results
+print(response.read().decode())
 ```
 
 ------


### PR DESCRIPTION
*Issue #, if available:*
N/A
*Description of changes:*

The current documentation only covers HTTPS over 8443.
Setting up HTTPS over 443 using ALPN can be confusing.
The code snippet is something I received from AWS support.

Future work:
- Add some more details
- Add args
- Use requests / urllib

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
