### PR TITLE
Missing Service Designation

### DIFF
--- a/developerguide/provision-wo-cert.md
+++ b/developerguide/provision-wo-cert.md
@@ -104,7 +104,7 @@ You must manage the trusted user's access and permission to perform this procedu
            "iot:CreateProvisioningClaim"
        ],
        "Resource": [
-           "arn:aws:aws-region:aws-account-id:provisioningtemplate/templateName"
+           "arn:aws:aws-service:aws-region:aws-account-id:provisioningtemplate/templateName"
        ]
    }
    ```


### PR DESCRIPTION
The iot:CreateProvisioningClaim Policy's Resource value was missing the aws-service designation (in this case it should be "iot"), so it should have either a placeholder as I've suggested ("aws-service") or "iot" listed in it's place.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
