### PR TITLE
Publish resource should be arn:aws:iot:region

### DIFF
--- a/developerguide/config-custom-auth.md
+++ b/developerguide/config-custom-auth.md
@@ -140,7 +140,7 @@ var generateAuthResponse = function(token, effect) {
         {
           "Action": "iot:Publish",
           "Effect": "Allow",
-          "Resource": "arn:aws:region:accountId:topic/telemetry/${iot:ClientId}"
+          "Resource": "arn:aws:iot:region:accountId:topic/telemetry/${iot:ClientId}"
         },
         {
           "Action": "iot:Subscribe",


### PR DESCRIPTION


*Issue #, if available:*

*Description of changes:*

`arn:aws:region` should be `arn:aws:iot:region`

it's right in `    publishStatement.Resource = ["arn:aws:iot:us-east-1:123456789012:topic/telemetry/myClientName"]; ` but wrong in the json

https://docs.aws.amazon.com/service-authorization/latest/reference/list_awsiot.html#awsiot-resources-for-iam-policies

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
