### PR TITLE
Update iot-create-rule.md

### DIFF
--- a/developerguide/iot-create-rule.md
+++ b/developerguide/iot-create-rule.md
@@ -150,7 +150,7 @@ The following is an example payload file with a rule that pushes data to an Amaz
   "awsIotSqlVersion": "2016-03-23",
   "actions": [{
       "firehose": {
-          "roleArn": ""arn:aws:iam::123456789012:role/my-iot-role",
+          "roleArn": "arn:aws:iam::123456789012:role/my-iot-role",
           "deliveryStreamName": "my-stream-name"
       }
   }]


### PR DESCRIPTION
removed errant double quote (") from Amazon Kinesis Data Firehose stream example rule.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
